### PR TITLE
fixed issue concerning openssl_verify not retuning boolean

### DIFF
--- a/saml/lib/xmlseclibs.php
+++ b/saml/lib/xmlseclibs.php
@@ -487,7 +487,7 @@ class XMLSecurityKey {
 	    if (! empty($this->cryptParams['digest'])) {
 	        $algo = $this->cryptParams['digest'];
 	    }
-        return openssl_verify ($data, $signature, $this->key, $algo);
+        return 1 === openssl_verify ($data, $signature, $this->key, $algo);
     }
 
     public function encryptData($data) {


### PR DESCRIPTION
openssl_verify can return a -1 (when an error occurs) instead of 1 or 0.
a -1 can be evaulated as true and thus can be falsly evaluated.